### PR TITLE
Convert all permalink URLs to lowercase

### DIFF
--- a/app/src/main/java/augsburg/se/alltagsguide/common/Page.java
+++ b/app/src/main/java/augsburg/se/alltagsguide/common/Page.java
@@ -122,7 +122,7 @@ public class Page implements Serializable, Newer<Page> {
         }
         String description = jsonPage.get("excerpt").getAsString();
         String content = jsonPage.get("content").getAsString();
-        String permalink = Helper.shortenUrl(jsonPage.get("permalink").getAsJsonObject().get("url").getAsString());
+        String permalink = Helper.shortenUrl(jsonPage.get("permalink").getAsJsonObject().get("url").getAsString().replaceAll("%", "").toLowerCase());
         int parentId = jsonPage.get("parent").getAsInt();
         int order = jsonPage.get("order").getAsInt();
         String thumbnail = jsonPage.get("thumbnail").isJsonNull() ? "" : jsonPage.get("thumbnail").getAsString();

--- a/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
+++ b/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
@@ -24,7 +24,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.MailTo;
 import android.net.Uri;
-import android.util.Log;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 

--- a/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
+++ b/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
@@ -24,6 +24,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.MailTo;
 import android.net.Uri;
+import android.util.Log;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -163,6 +164,7 @@ public class MyWebViewClient extends WebViewClient {
     }
 
     public Page findByPermalink(String url) {
+        url = url.replaceAll("%", "").toLowerCase();
         SQLiteQueryBuilder queryBuilder = getPermaLinkQuery(url);
 
         Cursor cursor = mDbCache.executeRawQuery(queryBuilder);


### PR DESCRIPTION
Fixes not working arabic links. URLs from links used upper case HTML codes, while the database stored lowercase permalinks.