### PR TITLE
Paragraph style

### DIFF
--- a/app/src/main/assets/style.css
+++ b/app/src/main/assets/style.css
@@ -1,3 +1,7 @@
+p {
+    margin-top: 0em;
+    margin-bottom: 0.8em;
+}
 table.generated_for_mobile {
     border-spacing:0; /* Removes the cell spacing via CSS */
     border-collapse: collapse;  /* Optional - if you don't want to have double border where cells touch */
@@ -58,9 +62,8 @@ dfn {
     font - style: italic
 }
 h1 {
-    font - size: 2e m;
-    margin: 0.67e m
-    0
+    font-size: 2 em;
+    margin: 0.67em;
 }
 mark {
     background: #ff0;color: #000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:1em

--- a/app/src/main/java/augsburg/se/alltagsguide/common/Page.java
+++ b/app/src/main/java/augsburg/se/alltagsguide/common/Page.java
@@ -122,7 +122,7 @@ public class Page implements Serializable, Newer<Page> {
         }
         String description = jsonPage.get("excerpt").getAsString();
         String content = jsonPage.get("content").getAsString();
-        String permalink = Helper.shortenUrl(jsonPage.get("permalink").getAsJsonObject().get("url").getAsString());
+        String permalink = Helper.shortenUrl(jsonPage.get("permalink").getAsJsonObject().get("url").getAsString().replaceAll("%", "").toLowerCase());
         int parentId = jsonPage.get("parent").getAsInt();
         int order = jsonPage.get("order").getAsInt();
         String thumbnail = jsonPage.get("thumbnail").isJsonNull() ? "" : jsonPage.get("thumbnail").getAsString();

--- a/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
+++ b/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
@@ -24,7 +24,6 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.MailTo;
 import android.net.Uri;
-import android.util.Log;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 

--- a/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
+++ b/app/src/main/java/augsburg/se/alltagsguide/utilities/ui/MyWebViewClient.java
@@ -24,6 +24,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteQueryBuilder;
 import android.net.MailTo;
 import android.net.Uri;
+import android.util.Log;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -163,6 +164,7 @@ public class MyWebViewClient extends WebViewClient {
     }
 
     public Page findByPermalink(String url) {
+        url = url.replaceAll("%", "").toLowerCase();
         SQLiteQueryBuilder queryBuilder = getPermaLinkQuery(url);
 
         Cursor cursor = mDbCache.executeRawQuery(queryBuilder);


### PR DESCRIPTION
Currently the API is stripping p-tags with its styles. This behaviour removes LTR and LTR attributes which are needed when working with arabic texts.

This pull request together with https://github.com/Integreat/cms/pull/414 leaves p-tags in and only replaces \\n with \<br\>.

For better viewing, a paragraph spacing of 0.8em is inserted.